### PR TITLE
Search page improvements, fixing event error

### DIFF
--- a/chromeshack.css
+++ b/chromeshack.css
@@ -26,7 +26,7 @@ img.imageloader { max-width: 600px; max-height: 600px; }
     border:1px solid #AEAE9B;
     padding:3px;
     background:#222;
-    height:230px;
+    height:200px;
     width:570px;
     overflow:auto;
 }

--- a/default_settings.js
+++ b/default_settings.js
@@ -28,8 +28,10 @@ DefaultSettings = {
     lol_show_counts: 'limited',
 
     lol_ugh_threshold: '0',
-
+    
     post_preview_location: "Left",
+    
+    post_preview_live: false,
 
     mod_marker_css: "color: red !important",
 

--- a/manifest.json
+++ b/manifest.json
@@ -66,9 +66,11 @@
     {
         "js": [ 
             "common.js",
+            "init_events.js",
             "default_settings.js",
             "settings.js",
-            "scripts/shack-userpopup.user.js"
+            "scripts/shack-userpopup.user.js",
+            "scripts/search.js"
         ],
         "matches": [ "*://www.shacknews.com/*" ],
         "exclude_matches": [

--- a/options.css
+++ b/options.css
@@ -36,7 +36,7 @@ h2.group { font-size: 18pt; margin-top: 25px; background: #3264C8; color: white;
    padding-bottom: 5px; text-align: center; }
 div.group_header { font-size: 12pt; font-weight: bold; color: white; margin-top: 15px; }
 
-div#video_loader_settings, div#highlight_users_settings, div#nws_incognito_settings { margin-left: 25px; }
+div#video_loader_settings, div#highlight_users_settings { margin-left: 25px; }
 div#category_banners_settings ul, div#expiration_watcher_settings ul, div#post_preview_settings ul 
    { list-style-type: none; padding-left: 25px; }
 

--- a/options.html
+++ b/options.html
@@ -222,6 +222,8 @@
                     <li><input type="radio" name="post_preview_location" id="post_preview_left"/><label for="post_preview_left">Left of post button</label></li>
                     <li><input type="radio" name="post_preview_location" id="post_preview_right"/><label for="post_preview_right">Right of post button</label></li>
                 </ul>
+                <input type="checkbox" class="script_check" id="post_preview_live" />
+                <label for="post_preview_live">Live preview (as you type!)</label>
             </div>
 
             <h2>

--- a/options.js
+++ b/options.js
@@ -2,6 +2,7 @@ function loadOptions()
 {
     showLolTags(getOption("lol_tags"), getOption("lol_show_counts"), getOption("lol_ugh_threshold"));
     showPostPreviewLocation(getOption("post_preview_location"));
+    showPostPreviewLive(getOption("post_preview_live"));
     showCategoryBanners(getOption("category_banners_visible"));
     showHighlightUsers(getOption("highlight_users"));
     showVideoLoaderHD(getOption("video_loader_hd"));
@@ -214,6 +215,18 @@ function getPostPreviewLocation()
     if (left.checked)
         return "Left";
     return "Right";
+}
+
+function showPostPreviewLive(enabled)
+{
+    var live = document.getElementById("post_preview_live");
+    live.checked = enabled;
+}
+
+function getPostPreviewLive()
+{
+    var live = document.getElementById("post_preview_live");
+    return live.checked;
 }
 
 function showExpirationWatcherStyle(style)
@@ -506,6 +519,7 @@ function saveOptions()
         saveOption("lol_show_counts", getLolShowCounts());
         saveOption("lol_ugh_threshold", getLolUghThreshhold());
         saveOption("post_preview_location", getPostPreviewLocation());
+        saveOption("post_preview_live", getPostPreviewLive());
         saveOption("category_banners_visible", getCategoryBanners());
         saveOption("enabled_scripts", getEnabledScripts());
         saveOption("highlight_users", getHighlightGroups());

--- a/scripts/post_preview.js
+++ b/scripts/post_preview.js
@@ -64,37 +64,44 @@ settingsLoadedEvent.addHandler(function()
 
             generatePreview: function(text)
             {
-                var preview = text.replace(/&/g, "&amp;");
-                preview = preview.replace(/</g, "&lt;");
-                preview = preview.replace(/>/g, "&gt;");
-                preview = preview.replace(/r{/g, '<span class="jt_red">');
-                preview = preview.replace(/g{/g, '<span class="jt_green">');
-                preview = preview.replace(/b{/g, '<span class="jt_blue">');
-                preview = preview.replace(/y{/g, '<span class="jt_yellow">');
-                preview = preview.replace(/e\[/g, '<span class="jt_olive">');
-                preview = preview.replace(/l\[/g, '<span class="jt_lime">');
-                preview = preview.replace(/n\[/g, '<span class="jt_orange">');
-                preview = preview.replace(/p\[/g, '<span class="jt_pink">');
-                preview = preview.replace(/q\[/g, '<span class="jt_quote">');
-                preview = preview.replace(/s\[/g, '<span class="jt_sample">');
-                preview = preview.replace(/-\[/g, '<span class="jt_strike">');
-                preview = preview.replace(/}r|}g|}b|}y|\]e|\]l|\]n|\]p|\]q|\]s|\]-|\]o/g, "</span>");
-                preview = preview.replace(/i\[/g, "<i>");
-                preview = preview.replace(/\]i/g, "</i>");
-                preview = preview.replace(/\/\[/g, "<i>");
-                preview = preview.replace(/\]\//g, "</i>");
-                preview = preview.replace(/b\[/g, "<b>");
-                preview = preview.replace(/\]b/g, "</b>");
-                preview = preview.replace(/\*\[/g, "<b>");
-                preview = preview.replace(/\]\*/g, "</b>");
-                preview = preview.replace(/_\[/g, "<u>");
-                preview = preview.replace(/\]_/g, "</u>");
-                preview = preview.replace(/o\[/g, '<span class="jt_spoiler" onclick="return doSpoiler(event);">');
-                preview = preview.replace(/\/{{/g, '<pre class="jt_code">');
-                preview = preview.replace(/}}\//g, "</pre>");
-                preview = preview.replace(/\r\n/g, "<br>");
-                preview = preview.replace(/\n/g, "<br>");
-                preview = preview.replace(/\r/g, "<br>");
+                var preview = text;
+
+                var regexReplacements = {
+                    '<': '&lt;',
+                    '>': '&gt;',
+                    'r{(.*)}r': '<span class="jt_red">$1</span>',
+                    'g{(.*)}g': '<span class="jt_green">$1</span>',
+                    'b{(.*)}b': '<span class="jt_blue">$1</span>',
+                    'y{(.*)}y': '<span class="jt_yellow">$1</span>',
+                    'e\\[(.*)\\]e': '<span class="jt_olive">$1</span>',
+                    'l\\[(.*)\\]l': '<span class="jt_lime">$1</span>',
+                    'n\\[(.*)\\]n': '<span class="jt_orange">$1</span>',
+                    'p\\[(.*)\\]p': '<span class="jt_pink">$1</span>',
+                    'q\\[(.*)\\]q': '<span class="jt_quote">$1</span>',
+                    's\\[(.*)\\]s': '<span class="jt_sample">$1</span>',
+                    '-\\[(.*)\\]-': '<span class="jt_strike">$1</span>',
+                    'i\\[(.*)\\]i': '<i>$1</i>',
+                    '\\/\\[(.*)\\]\\/': '<i>$1</i>',
+                    'b\\[(.*)\\]b': '<b>$1</b>',
+                    '\\*\\[(.*)\\]\\*': '<b>$1</b>',
+                    '_\\[(.*)\\]_': '<u>$1</u>',
+                    'o\\[(.*)\\]o': '<span class="jt_spoiler" onclick="return doSpoiler(event);">$1</span>',
+                    '\\/{{(.*)}}\\/': '<pre class="jt_code">$1</pre>',
+                    '\\r\\n': '<br>',
+                    '\\n': '<br>',
+                    '\\r': '<br>'
+                };
+
+                preview = preview.replace("/&/g", "&amp;");
+                for(var ix in regexReplacements) {
+                    if(regexReplacements.hasOwnProperty(ix)) {
+                        var rgx = new RegExp(ix, 'g');
+                        while(preview.match(rgx) !== null) {
+                            preview = preview.replace(rgx, regexReplacements[ix]);
+                        }
+                    }
+                }
+
                 preview = PostPreview.ConvertUrlToLink(preview);
 
                 return preview;

--- a/scripts/post_preview.js
+++ b/scripts/post_preview.js
@@ -34,7 +34,8 @@ settingsLoadedEvent.addHandler(function()
                 var previewArea = document.getElementById("previewArea");
 
                 previewButton.addEventListener("click", PostPreview.togglePreview, true);
-                previewArea.addEventListener("click", PostPreview.togglePreview, true);
+                if(getSetting("post_preview_live") === false)
+                    previewArea.addEventListener("click", PostPreview.togglePreview, true);
             },
 
             togglePreview: function()
@@ -51,53 +52,83 @@ settingsLoadedEvent.addHandler(function()
                 var form_body = document.getElementById("frm_body");
                 previewArea.innerHTML = PostPreview.generatePreview(form_body.value);
                 previewArea.style.display = "block"; 
-                form_body.style.display = "none"; 
+                if(getSetting("post_preview_live") === false) {
+                    form_body.style.display = "none";
+                } else {
+                    form_body.addEventListener("input", PostPreview.updatePreview, true)
+                }
                 PostPreview.state = 1;
             },
 
             viewSource: function()
             {
-                document.getElementById("frm_body").style.display = "block"; 
+                var form_body = document.getElementById("frm_body");
+                if(getSetting("post_preview_live") === true) {
+                    form_body.removeEventListener("input", PostPreview.updatePreview, true)
+                }
+                form_body.style.display = "block"; 
                 document.getElementById("previewArea").style.display = "none"; 
                 PostPreview.state = 0;
+            },
+
+            updatePreview: function()
+            {
+                document.getElementById("previewArea").innerHTML = PostPreview.generatePreview(document.getElementById("frm_body").value);
             },
 
             generatePreview: function(text)
             {
                 var preview = text;
 
-                var regexReplacements = {
-                    '<': '&lt;',
-                    '>': '&gt;',
-                    'r{(.*)}r': '<span class="jt_red">$1</span>',
-                    'g{(.*)}g': '<span class="jt_green">$1</span>',
-                    'b{(.*)}b': '<span class="jt_blue">$1</span>',
-                    'y{(.*)}y': '<span class="jt_yellow">$1</span>',
-                    'e\\[(.*)\\]e': '<span class="jt_olive">$1</span>',
-                    'l\\[(.*)\\]l': '<span class="jt_lime">$1</span>',
-                    'n\\[(.*)\\]n': '<span class="jt_orange">$1</span>',
-                    'p\\[(.*)\\]p': '<span class="jt_pink">$1</span>',
-                    'q\\[(.*)\\]q': '<span class="jt_quote">$1</span>',
-                    's\\[(.*)\\]s': '<span class="jt_sample">$1</span>',
-                    '-\\[(.*)\\]-': '<span class="jt_strike">$1</span>',
-                    'i\\[(.*)\\]i': '<i>$1</i>',
-                    '\\/\\[(.*)\\]\\/': '<i>$1</i>',
-                    'b\\[(.*)\\]b': '<b>$1</b>',
-                    '\\*\\[(.*)\\]\\*': '<b>$1</b>',
-                    '_\\[(.*)\\]_': '<u>$1</u>',
-                    'o\\[(.*)\\]o': '<span class="jt_spoiler" onclick="return doSpoiler(event);">$1</span>',
-                    '\\/{{(.*)}}\\/': '<pre class="jt_code">$1</pre>',
-                    '\\r\\n': '<br>',
-                    '\\n': '<br>',
-                    '\\r': '<br>'
+                // simple replacements
+                preview = preview.replace(/&/g, "&amp;");
+                preview = preview.replace(/</g, "&lt;");
+                preview = preview.replace(/>/g, "&gt;");
+                preview = preview.replace(/\r\n/g, "<br>");
+                preview = preview.replace(/\n/g, "<br>");
+                preview = preview.replace(/\r/g, "<br>");
+
+                var complexReplacements = {
+                    'red': {'from': ['r{','}r'], 'to': ['<span class="jt_red">','</span>']},
+                    'green': {'from': ['g{','}g'], 'to': ['<span class="jt_green">','</span>']},
+                    'blue': {'from': ['b{','}b'], 'to': ['<span class="jt_blue">','</span>']},
+                    'yellow': {'from': ['y{','}y'], 'to': ['<span class="jt_yellow">','</span>']},
+                    'olive': {'from': ['e\\[','\\]e'], 'to': ['<span class="jt_olive">','</span>']},
+                    'lime': {'from': ['l\\[','\\]l'], 'to': ['<span class="jt_lime">','</span>']},
+                    'orange': {'from': ['n\\[','\\]n'], 'to': ['<span class="jt_orange">','</span>']},
+                    'pink': {'from': ['p\\[','\\]p'], 'to': ['<span class="jt_pink">','</span>']},
+                    'quote': {'from': ['q\\[','\\]q'], 'to': ['<span class="jt_quote">','</span>']},
+                    'sample': {'from': ['s\\[','\\]s'], 'to': ['<span class="jt_sample">','</span>']},
+                    'strike': {'from': ['-\\[','\\]-'], 'to': ['<span class="jt_strike">','</span>']},
+                    'italic1': {'from': ['i\\[','\\]i'], 'to': ['<i>','</i>']},
+                    'italic2': {'from': ['\\/\\[','\\]\\/'], 'to': ['<i>','</i>']},
+                    'bold1': {'from': ['b\\[','\\]b'], 'to': ['<b>','</b>']},
+                    'bold2': {'from': ['\\*\\[','\\]\\*'], 'to': ['<b>','</b>']},
+                    'underline': {'from': ['_\\[','\\]_'], 'to': ['<u>','</u>']},
+                    'spoiler': {'from': ['o\\[','\\]o'], 'to': ['<span class="jt_spoiler" onclick="return doSpoiler(event);">','</span>']},
+                    'code': {'from': ['\\/{{','}}\\/'], 'to': ['<pre class="jt_code">','</pre>']}
                 };
 
-                preview = preview.replace("/&/g", "&amp;");
-                for(var ix in regexReplacements) {
-                    if(regexReplacements.hasOwnProperty(ix)) {
-                        var rgx = new RegExp(ix, 'g');
+                // replace matching pairs first
+                for(var ix in complexReplacements) {
+                    if(complexReplacements.hasOwnProperty(ix)) {
+                        var rgx = new RegExp(complexReplacements[ix].from[0] + '(.*?)' + complexReplacements[ix].from[1], 'g');
                         while(preview.match(rgx) !== null) {
-                            preview = preview.replace(rgx, regexReplacements[ix]);
+                            preview = preview.replace(rgx, complexReplacements[ix].to[0] + '$1' + complexReplacements[ix].to[1]);
+                        }
+                    }
+                }
+
+                // replace orphaned opening shacktags, close them at the end of the post.
+                // this still has (at least) one bug, the shack code does care about nested tag order:
+                // b[g{bold and green}g]b <-- correct
+                // b[g{bold and green]b}g <-- }g is not parsed by the shack code
+                for(var ix in complexReplacements) {
+                    if(complexReplacements.hasOwnProperty(ix)) {
+                        var rgx = new RegExp(complexReplacements[ix].from[0], 'g');
+                        while(preview.match(rgx) !== null) {
+                            preview = preview.replace(rgx, complexReplacements[ix].to[0]);
+                            preview = preview + complexReplacements[ix].to[1];
                         }
                     }
                 }

--- a/scripts/search.js
+++ b/scripts/search.js
@@ -1,0 +1,20 @@
+(function() {
+    if(document.body.classList.contains('page-search')) {
+        var searchResults = getDescendentByTagAndClassName(document, "ul", "results");
+        var searchLinks = searchResults.getElementsByTagName("a");
+        for(var i=0; i<searchLinks.length; i++) {
+            var postId = searchLinks[i].href.match(/chatty\/(\d+)/i);
+            if(postId && postId.length == 2) {
+                searchLinks[i].href = 'http://www.shacknews.com/chatty?id=' + postId[1] + '#item_' + postId[1];
+            }
+        }
+    }
+    insertStyle(
+        "body.page-search div#full-wrap div#main div.pagination { color: #666; }" +
+        "body.page-search div#full-wrap div#main div.pagination a { color: #fff; }" +
+        "body.page-search div#full-wrap div#main span.sort-results { color: #fff; }" +
+        "body.page-search div#full-wrap div#main h2.search-num-found { color: #fff; }" +
+        "body.page-search div#full-wrap div#main ul.results span.chatty-author a.more { color: #00f; }" +
+        "body.page-search div#full-wrap div#main ul.results span.postdate { color: #aaa; }"
+    );
+})();


### PR DESCRIPTION
* settingsLoadedEvent wasn't defined outside chatty, logging an error and possibly making some scripts not run?
* Fixed older search results that were linking to news posts and not the actual chatty comments
* Made text color on search results page more readable
* Made post previews more honest, no longer eats up extra end-tags