### PR TITLE
SocialLoader loads tweets

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -32,6 +32,7 @@
             "scripts/category_banners.js",
             "scripts/image_loader.js",
             "scripts/video_loader.js",
+            "scripts/social_loader.js",
             "scripts/sparkly_comic.js",
             "scripts/collapse.js",
             "scripts/sfw.js",
@@ -92,6 +93,7 @@
         , "http://shackapi.stonedonkey.com/*"
         , "*://*.shacknews.com/*"
         , "*://*.bit-shift.com/*"
+        , "*://chatty.nevares.com/*"
     ],
     "web_accessible_resources": [
         "scripts/video_loader_helper.js",

--- a/options.html
+++ b/options.html
@@ -102,6 +102,11 @@
                     <input type="checkbox" id="video_loader_hd"/><label for="video_loader_hd">Show in HD (when available)</label>
                 </div>
                 <p>
+                    <input type="checkbox" class="script_check" id="social_loader" />
+                    <label for="social_loader">Embed social links</label>
+                </p>
+                <p class="indent info">Replace links to Twitter with the link's embedded content.</p>
+                <p>
                     <input type="checkbox" class="script_check" id="getpost" />
                     <label for="getpost">Embed posts</label>
                 </p>

--- a/scripts/social_loader.js
+++ b/scripts/social_loader.js
@@ -1,0 +1,115 @@
+settingsLoadedEvent.addHandler(function()
+{
+    if (getSetting("enabled_scripts").contains("social_loader"))
+    {
+        SocialLoader =
+        {
+            SOCIAL_TYPE_NONE: 0,
+            SOCIAL_TYPE_TWITTER: 1,
+
+            tweetCache: {},
+
+            loadSocial: function(item, id)
+            {
+                var postbody = getDescendentByTagAndClassName(item, "div", "postbody");
+                var links = postbody.getElementsByTagName("a");
+
+                for (var i = 0; i < links.length; i++)
+                {
+                    var type = SocialLoader.getSocialType(links[i].href);
+                    if (type != SocialLoader.SOCIAL_TYPE_NONE)
+                    {
+                        links[i].addEventListener("click", SocialLoader.toggleSocial, false);
+                    }
+                }
+            },
+
+            getSocialType: function(url)
+            {
+                if (url.match(/twitter\.com\/\w+\/status\/\d+.*/i))
+                    return SocialLoader.SOCIAL_TYPE_TWITTER;
+
+                return SocialLoader.SOCIAL_TYPE_NONE;
+            },
+
+            toggleSocial: function(e)
+            {
+                // left click only
+                if (e.button === 0)
+                {
+                    var link = this;
+                    // if there is an embed after the link, remove it
+                    if (link.nextSibling !== null && link.nextSibling.className === "SocialLoader")
+                    {
+                        link.parentNode.removeChild(link.nextSibling);
+                    }
+                    else
+                    {
+                        var type = SocialLoader.getSocialType(link.href);
+
+                        if (type === SocialLoader.SOCIAL_TYPE_TWITTER)
+                            SocialLoader.fetchTwitter(link);
+                    }
+
+                    e.preventDefault();
+                }
+            },
+
+            fetchTwitter: function(link)
+            {
+                if(SocialLoader.tweetCache.hasOwnProperty(link))
+                {
+                    SocialLoader.createTwitter(link, SocialLoader.tweetCache[link]);
+                }
+                else
+                {
+                    var loader = document.createElement("img");
+                    loader.className = "SocialLoaderGif";
+                    loader.src = chrome.extension.getURL("images/loading-pinned.gif");
+                    link.parentNode.insertBefore(loader, link.nextSibling);
+
+                    $.ajax({
+                        url: "http://chatty.nevares.com/tweet",
+                        data: "tweetUrl=" + link.href,
+                        dataType: "html",
+                        timeout: 5000,
+                        success: function(data)
+                        {
+                            SocialLoader.createTwitter(link, data);
+                            SocialLoader.tweetCache[link] = data;
+                        },
+                        error: function()
+                        {
+                            // GET failed, fall back to opening the link
+                            window.open(link.href);
+                        }
+                    });
+                }
+            },
+
+            createTwitter: function(link, data)
+            {
+                if (link.nextSibling !== null && link.nextSibling.className === "SocialLoaderGif")
+                {
+                    link.parentNode.removeChild(link.nextSibling);
+                }
+
+                var div = document.createElement("div");
+                div.className = "SocialLoader";
+                div.innerHTML = data;
+                div.firstChild.setAttribute("data-theme", "dark");
+
+                // add the embed right after the link
+                link.parentNode.insertBefore(div, link.nextSibling);
+
+                var twitterWidget = document.createElement("script");
+                twitterWidget.setAttribute("async", "");
+                twitterWidget.setAttribute("src", "//platform.twitter.com/widgets.js");
+                twitterWidget.setAttribute("charset", "utf-8");
+                document.head.appendChild(twitterWidget);
+            }
+        };
+
+        processPostEvent.addHandler(SocialLoader.loadSocial);
+    }
+});


### PR DESCRIPTION
I wrote a [Twitter proxy](https://github.com/pnevares/twitter-reader) that's [running on AWS](http://chatty.nevares.com/latest) to fetch and cache tweets linked within posts. Thanks to @electroly's stellar advice it uses the Winchatty api to monitor new posts so they should be cached before a user clicks the link in 99% of cases.

* Any reasons this shouldn't default to enabled?
* I've seen some Chromeshack HTTPS support here and there, is that something I need to worry about?
* Anything else, let me know.