### PR TITLE
New option: shorten long posts

### DIFF
--- a/chromeshack.css
+++ b/chromeshack.css
@@ -161,6 +161,34 @@ body.shack_sfw td.date {color: #000 !important; }
 body.shack_sfw tr.odd {background-color: #eee !important; } 
 body.shack_sfw div.interiorcontent th, body.shack_sfw div.interiorform label { color: #000 !important; } 
 
+/* shorten posts */
+body.shorten_posts div.postbody {
+  max-height: 600px;
+  overflow-y: auto;
+}
+body.shorten_posts div.postbody.unshortened {
+  max-height: none;
+  overflow-y: visible;
+}
+body.shorten_posts div.toggle_shorten {
+    width: 19px;
+    height: 16px;
+    overflow: hidden;
+    position: absolute;
+    left: 0;
+    top: 45px;
+    text-align: center;
+}
+body.shorten_posts div.toggle_shorten a {
+    color: #555;
+    margin-left: 2px;
+    font-size: 16px;
+}
+body.shorten_posts div.toggle_shorten a:hover {
+    color: #bbb;
+    text-decoration: none;
+}
+
 /* new comment marker */
 span.newcommenthighlighter {
     /*border-bottom-color: #0099ff;

--- a/default_settings.js
+++ b/default_settings.js
@@ -11,6 +11,7 @@ DefaultSettings = {
         "collapse_threads",
         "dinogegtik",
         "sparkly_comic",
+        "shorten_posts",
         "winchatty_comments_search",
         "expiration_watcher",
         "nws_incognito",

--- a/manifest.json
+++ b/manifest.json
@@ -34,6 +34,7 @@
             "scripts/video_loader.js",
             "scripts/social_loader.js",
             "scripts/sparkly_comic.js",
+            "scripts/shorten_posts.js",
             "scripts/collapse.js",
             "scripts/sfw.js",
             "scripts/new_comment_highlighter.js",

--- a/options.html
+++ b/options.html
@@ -131,6 +131,11 @@
                     <label for="sparkly_comic">Sparkly comic</label>
                 </p>
                 <p class="indent info">Replace sparkly posts with a comic strip.</p>
+                <p>
+                    <input type="checkbox" class="script_check" id="shorten_posts" />
+                    <label for="shorten_posts">Shorten posts</label>
+                </p>
+                <p class="indent info">Shorten long posts, add a scrollbar.</p>
             </div>
 
             <h2>

--- a/release_notes.html
+++ b/release_notes.html
@@ -10,6 +10,7 @@
             <li>Added support for Vine to video loader. (king_darius)</li>
             <li>Updated mod/staff list. (Haxim)</li>
             <li>Chrome Shack settings window will now auto-save, can be reset to defaults. (king_darius)</li>
+            <li>Post enhancement: shorten long posts. (king_darius)</li>
         </ul>
         <h2>Version 1.45</h2>
         <ul>

--- a/scripts/shorten_posts.js
+++ b/scripts/shorten_posts.js
@@ -1,0 +1,56 @@
+// i ate a cat
+
+settingsLoadedEvent.addHandler(function()
+{
+    if (getSetting("enabled_scripts").contains("shorten_posts"))
+    {
+        ShortenPosts =
+        {
+            installCSS: function()
+            {
+                document.body.className += " shorten_posts";
+            },
+
+            installButton: function(item)
+            {
+                var postBody = getDescendentByTagAndClassName(item, "div", "postbody");
+
+                if(postBody.scrollHeight > 600)
+                {
+                    var fullpost = getDescendentByTagAndClassName(item, "div", "fullpost");
+
+                    var button = document.createElement("a");
+                    button.href = "#";
+                    button.innerText = "+";
+                    button.addEventListener("click", ShortenPosts.toggleShorten);
+
+                    var div = document.createElement("div");
+                    div.className = "toggle_shorten";
+                    div.appendChild(button);
+
+                    fullpost.appendChild(div);
+                }
+            },
+
+            toggleShorten: function(e)
+            {
+                e.preventDefault();
+                var fullpost = e.target.parentNode.parentNode;
+                var postBody = getDescendentByTagAndClassName(fullpost, "div", "postbody");
+                if(postBody.className.indexOf("unshortened") !== -1)
+                {
+                    postBody.className = "postbody";
+                    e.target.innerText = "+";
+                }
+                else
+                {
+                    postBody.className += " unshortened";
+                    e.target.innerText = "–";
+                }
+            },
+        };
+
+        processPostEvent.addHandler(ShortenPosts.installButton);
+        ShortenPosts.installCSS();
+    }
+});


### PR DESCRIPTION
This limits post heights to 600px and adds a scrollbar for the rest. Adds a +/- link to long posts to toggle shortened mode.

A 600px post body makes each post about two-thirds of a page, and leaves room for about 6 lines for post text above/below an embedded HD YouTube video.
