### PR TITLE
Support Firefox on Android

### DIFF
--- a/android.ps1
+++ b/android.ps1
@@ -1,0 +1,93 @@
+#Requires -Version 5
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 2.0
+
+Add-Type -Assembly 'System.IO.Compression.FileSystem'
+
+# returns the path to the .zip file
+function Build() {
+    $dir = (Join-Path ([System.IO.Path]::GetTempPath()) 'chromeshack-android-build')
+    Remove-Item -Recurse -Force $dir -ErrorAction SilentlyContinue
+    mkdir $dir | Out-Null
+
+    $nameMappings = New-Object 'Collections.ArrayList'
+    _CopyFiles -Prefix '' -SrcDir $PSScriptRoot -SrcRelativePath '' -DstDir $dir -NameMappings $nameMappings
+    foreach ($file in [System.IO.Directory]::GetFiles($dir)) {
+        _MangleFilenameReferencesInFile -FilePath $file -NameMappings $nameMappings
+    }
+
+    Remove-Item -Force (Join-Path $dir 'manifest.json')
+    Move-Item (Join-Path $dir 'manifest-android.json') (Join-Path $dir 'manifest.json')
+
+    $localXpiFilePath = (Join-Path ([System.IO.Path]::GetTempPath()) 'chromeshack-temp.zip')
+    Remove-Item -Force $localXpiFilePath -ErrorAction SilentlyContinue
+    [System.IO.Compression.ZipFile]::CreateFromDirectory($dir, $localXpiFilePath)
+    Remove-Item -Recurse -Force $dir -ErrorAction SilentlyContinue
+    return $localXpiFilePath
+}
+
+# this will zip up the project folder and copy it onto an attached Android device.
+# to install in Firefox for Android, navigate to file:///storage/self/primary/Documents/ in Firefox on the device
+function Debug() {
+    $localXpiFilePath = Build
+
+    # this is the Documents folder in the internal storage on a Samsung Galaxy Tab S4
+    & adb.exe push $localXpiFilePath '/storage/self/primary/Documents/chromeshack@electroly.com.xpi'
+
+    Remove-Item -Force $localXpiFilePath -ErrorAction SilentlyContinue
+}
+
+# ---
+# internal implementation
+# ---
+
+function _CopyFiles([string]$Prefix, [string]$SrcDir, [string]$SrcRelativePath, [string]$DstDir, [object]$NameMappings) {
+    $PrefixDash = ''
+    if ($Prefix -ne '') {
+        $PrefixDash = "$Prefix-"
+    }
+
+    $SrcRelativePathSlash = ''
+    if ($SrcRelativePath -ne '') {
+        $SrcRelativePathSlash = "$SrcRelativePath/"
+    }
+
+    $files = [System.IO.Directory]::GetFiles($srcDir)
+    foreach ($file in $files) {
+        $originalName = [System.IO.Path]::GetFileName($file)
+        $newName = $PrefixDash + $originalName
+        $newPath = (Join-Path $DstDir $newName)
+        if (-not $originalName.StartsWith('.')) {
+            Copy-Item $file $newPath
+            $NameMappings.Add([PSCustomObject]@{
+                'RelativePath' = $SrcRelativePathSlash + $originalName
+                'MangledName' = $newName
+            }) | Out-Null
+        }
+    }
+
+    $subdirs = [System.IO.Directory]::GetDirectories($srcDir)
+    foreach ($subdir in $subdirs) {
+        $subdirName = [System.IO.Path]::GetFileName($subdir)
+        if (-not $subdirName.StartsWith('.')) {
+            _CopyFiles -Prefix ($PrefixDash + $subdirName) -SrcDir $subdir -SrcRelativePath ($SrcRelativePathSlash + $subdirName) -DstDir $DstDir -NameMappings $NameMappings
+        }
+    }
+}
+
+function _MangleFilenameReferencesInFile([string]$FilePath, [object]$NameMappings) {
+    $quotes = @( '"', "'" )
+    $extension = [System.IO.Path]::GetExtension($FilePath)
+    if ($extension -eq '.html' -or $extension -eq '.js' -or $extension -eq '.json') {
+        $content = [System.IO.File]::ReadAllText($FilePath)
+        foreach ($nameMapping in $NameMappings) {
+            foreach ($quote in $quotes) {
+                $search = $quote + $nameMapping.RelativePath + $quote
+                $replace = $quote + $nameMapping.MangledName + $quote
+                $content = $content.Replace($search, $replace)
+            }
+        }
+        $content = $content.Replace('var isFirefoxAndroid = false;', 'var isFirefoxAndroid = true;');
+        [System.IO.File]::WriteAllText($FilePath, $content)
+    }
+}

--- a/manifest-android.json
+++ b/manifest-android.json
@@ -1,0 +1,128 @@
+{
+    "name": "Chrome Shack",
+    "version": "1.54",
+    "manifest_version": 2,
+    "description": "Collection of scripts for Shacknews.",
+    "options_ui": {
+        "page": "options.html"
+    },
+    "content_security_policy": "script-src 'self'; object-src 'self'",
+    "background": {
+        "scripts": [
+            "ext/webextension-polyfill/browser-polyfill.min.js",
+            "common.js",
+            "background.js"
+        ]
+    },
+    "page_action": {
+        "default_icon": "shack.png",
+        "default_title": "Chrome Shack",
+        "default_popup": "options.html"
+    },
+    "icons": {
+        "16": "shack.png",
+        "144": "icon.png"
+    },
+    "browser_specific_settings": {
+        "gecko": {
+            "id": "chromeshack@electroly.com"
+        }
+    },
+    "content_scripts": [{
+        "js": [
+            "ext/closure-library/crypt.js",
+            "ext/papaparse/papaparse.min.js",
+            "ext/webextension-polyfill/browser-polyfill.min.js",
+            "common.js",
+            "sentence_parser.js",
+            "init_events.js",
+            "scripts/lol.js",
+            "scripts/post_preview.js",
+            "scripts/dinogegtik.js",
+            "scripts/category_banners.js",
+            "scripts/image_loader.js",
+            "scripts/video_loader.js",
+            "scripts/sparkly_comic.js",
+            "scripts/collapse.js",
+            "scripts/comment_tags.js",
+            "scripts/new_comment_highlighter.js",
+            "scripts/highlight_users.js",
+            "scripts/local_timestamp.js",
+            "scripts/expiration_watcher.js",
+            "scripts/getpost.js",
+            "scripts/embed_socials.js",
+            "scripts/elder_scroll.js",
+            "scripts/nws_incognito.js",
+            "scripts/switchers.js",
+            "chromeshack_posts.js",
+            "default_settings.js",
+            "settings.js",
+            "scripts/media_helpers.js",
+            "scripts/shack-userpopup.user.js",
+            "scripts/jquery-3.3.1.min.js",
+            "scripts/jquery.drop.js",
+            "scripts/jquery.insert.js",
+            "scripts/image_upload.js",
+            "scripts/custom_user_filters.js",
+            "scripts/highlight_pending_new_posts.js",
+            "scripts/options_link.js",
+            "scripts/post_length_counter.js",
+            "scripts/thread_pane.js"
+        ],
+        "css": [
+            "styles/chromeshack.css",
+            "styles/image_uploader.css",
+            "styles/comic_scripts.css",
+            "styles/embed_socials.css",
+            "styles/two_pane.css",
+            "styles/media.css"
+         ],
+        "matches": [
+            "*://www.shacknews.com/chatty*",
+            "*://new.shacknews.com/chatty*",
+            "*://www.shacknews.com/article/*"
+        ],
+        "all_frames": false,
+        "run_at": "document_idle"
+    }],
+    "permissions": [
+        "storage",
+        "tabs",
+        "https://api.imgur.com/3/*",
+        "https://api.gfycat.com/v1/gfycats/*",
+        "https://filedrop.gfycat.com/*",
+        "https://chattypics.com/*",
+        "https://lol.lmnopc.com/*",
+        "https://winchatty.com/v2/*",
+        "https://winchatty.com/nusearch?*",
+        "https://shackstats.com/data/users_info.csv",
+        "https://embed.twitch.tv/embed/*",
+        "https://www.instagram.com/p/*",
+        "https://publish.twitter.com/*",
+        "https://*.youtube.com/embed/*",
+        "https://api.streamable.com/videos/*",
+        "*://*.shacknews.com/*",
+        "*://*.bit-shift.com/*"
+    ],
+    "web_accessible_resources": [
+        "images/banners/offtopic.png",
+        "images/banners/political.png",
+        "images/banners/stupid.png",
+        "images/banners/interesting.png",
+        "images/sparkly/sparkly1.jpg",
+        "images/sparkly/sparkly2.jpg",
+        "images/sparkly/sparkly3.jpg",
+        "images/sparkly/sparkly4.jpg",
+        "images/sparkly/sparkly5.jpg",
+        "images/sparkly/sparkly6.jpg",
+        "images/dinogegtik.png",
+        "images/doom_health.png",
+        "images/lol.png",
+        "images/loading-pinned.gif",
+        "images/banners/pinned.png",
+        "styles/options.css",
+        "shack.png",
+        "options.html",
+        "options.js"
+    ]
+}

--- a/manifest-android.json
+++ b/manifest-android.json
@@ -1,6 +1,6 @@
 {
     "name": "Chrome Shack",
-    "version": "1.54",
+    "version": "1.55",
     "manifest_version": 2,
     "description": "Collection of scripts for Shacknews.",
     "options_ui": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Chrome Shack",
-    "version": "1.54",
+    "version": "1.55",
     "manifest_version": 2,
     "description": "Collection of scripts for Shacknews.",
     "update_url": "http://clients2.google.com/service/update2/crx",

--- a/options.html
+++ b/options.html
@@ -141,19 +141,20 @@
                 <p class="indent info">Auto center and scroll to selected posts</p>
             </div>
 
-            <h2>
-                <input type="checkbox" class="script_check" id="enable_notifications">
-                <label for="enable_notifications">Push Notifications</label>
-            </h2>
-            <p class="info">
-                Use the WinChatty notification service to receive notifications when new posts matching specific criteria are made, even when Chrome is closed.  You must restart Chrome after enabling notifications.
-            </p>
-            <div id="enable_notifications_settings">
-                <p>
-                    <a href="https://winchatty.com/v2/notifications/ui/configure" target="_blank">Change notification options...</a>
+            <div class="desktop_only">
+                <h2>
+                    <input type="checkbox" class="script_check" id="enable_notifications">
+                    <label for="enable_notifications">Push Notifications</label>
+                </h2>
+                <p class="info">
+                    Use the WinChatty notification service to receive notifications when new posts matching specific criteria are made, even when Chrome is closed.  You must restart Chrome after enabling notifications.
                 </p>
+                <div id="enable_notifications_settings">
+                    <p>
+                        <a href="https://winchatty.com/v2/notifications/ui/configure" target="_blank">Change notification options...</a>
+                    </p>
+                </div>
             </div>
-
 
             <h2 class="group">Viewing Threads</h2>
 
@@ -168,11 +169,13 @@
             </h2>
             <p class="info">Color highlighting within the tree of thread replies.</p>
             <div>
-                <p>
-                    <input type="checkbox" class="script_check" id="highlight_pending_new_posts" />
-                    <label for="highlight_pending_new_posts">Highlight refresh button when new posts are available</label>
-                </p>
-                <p class="indent info">Use the WinChatty push service to highlight threads that have received new replies that you need to refresh to see.  A button at the top of the chatty indicates how many threads have new posts and, upon clicking the button, will take you to the next thread with new posts.</p>
+                <div class="desktop_only">
+                    <p>
+                        <input type="checkbox" class="script_check" id="highlight_pending_new_posts" />
+                        <label for="highlight_pending_new_posts">Highlight refresh button when new posts are available</label>
+                    </p>
+                    <p class="indent info">Use the WinChatty push service to highlight threads that have received new replies that you need to refresh to see.  A button at the top of the chatty indicates how many threads have new posts and, upon clicking the button, will take you to the next thread with new posts.</p>
+                </div>
                 <p>
                     <input type="checkbox" class="script_check" id="new_comment_highlighter" />
                     <label for="new_comment_highlighter">Highlight new posts since last refresh</label>

--- a/release_notes.html
+++ b/release_notes.html
@@ -1,5 +1,6 @@
 <html>
     <head>
+        <meta charset="UTF-8" />
         <title>Chrome Shack Release Notes</title>
         <style>
             body { font-family: helvetica, arial, sans-serif; font-size: 16px; margin: 1.5em; }
@@ -8,6 +9,10 @@
     </head>
     <body>
         <h1>Chrome Shack Release Notes</h1>
+        <h2>Version 1.55</h2>
+        <ul>
+            <li>New: Chrome Shack now runs on Firefox on Android (electroly)</li>
+        </ul>
         <h2>Version 1.54</h2>
         <ul>
             <li>New: "Embed Socials" embeds Twitter and Instagram posts inline when links are clicked (WombatFromHell)</li>

--- a/scripts/highlight_pending_new_posts.js
+++ b/scripts/highlight_pending_new_posts.js
@@ -1,4 +1,6 @@
 (function() {
+    var isFirefoxAndroid = false;
+
     var g_lastEventId = 0;
 
     function startsWith(haystack, needle) {
@@ -141,6 +143,10 @@
     }
 
     function install() {
+        if (isFirefoxAndroid) {
+            return; // desktop only
+        }
+
         // Only install on the main /chatty page, not an individual thread.
         if (document.getElementById('newcommentbutton') === null) {
             return;

--- a/scripts/thread_pane.js
+++ b/scripts/thread_pane.js
@@ -1,6 +1,8 @@
 let refreshThreadPane;
 
 (() => {
+    var isFirefoxAndroid = false;
+
     refreshThreadPane = () => {
         if (getSetting('enabled_scripts').contains('thread_pane')) {
             try {
@@ -90,7 +92,7 @@ let refreshThreadPane;
             for (let i = 0; i < mostRecentSubtree.length; i++) {
                 const { postAuthor, postPreviewHtml } = mostRecentSubtree[i];
                 const $postDiv = $('<div class="cs_thread_pane_reply">');
-                $postDiv.append($('<div class="cs_thread_pane_reply_arrow">').text('↪'));
+                $postDiv.append($('<div class="cs_thread_pane_reply_arrow">').text(isFirefoxAndroid ? '–' : '↪'));
                 $postDiv.append($('<div class="cs_thread_pane_reply_preview">').html(postPreviewHtml));
                 $postDiv.append($('<div class="cs_thread_pane_reply_divider">').text(':'));
                 $postDiv.append($('<div class="cs_thread_pane_reply_author">').text(postAuthor));

--- a/settings.js
+++ b/settings.js
@@ -1,5 +1,6 @@
 //content-script accessible copy of localStorage
 var settings;
+var isFirefoxAndroid = false;
 
 // utility function to get a setting out of the local storage snapshot
 function getSetting(name)
@@ -11,18 +12,35 @@ function getSetting(name)
 }
 
 function reloadSettings(raiseEvent) {
-    browser.runtime.sendMessage({name: "getSettings"}).then(function(response)
-    {
-        settings = response;
-        if (raiseEvent) {
-            settingsLoadedEvent.raise();
-        }
-    });
+    if (isFirefoxAndroid) {
+        browser.storage.local.get("settings")
+            .then(
+                function success(result) {
+                    settings = result.settings || {};
+                    if (raiseEvent) {
+                        settingsLoadedEvent.raise();
+                    }
+                },
+                function error(e) {
+                    settings = {};
+                });
+    } else {
+        browser.runtime.sendMessage({name: "getSettings"}).then(function(response)
+        {
+            settings = response;
+            if (raiseEvent) {
+                settingsLoadedEvent.raise();
+            }
+        });
+    }
 }
 
-function setSetting(name, value)
-{
-    browser.runtime.sendMessage({name: "setSetting", key: name, value: value});
+function setSetting(name, value) {
+    if (isFirefoxAndroid) {
+        browser.storage.local.set({ settings });
+    } else {
+        browser.runtime.sendMessage({name: "setSetting", key: name, value: value});
+    }
 }
 
 reloadSettings(true);

--- a/styles/options.css
+++ b/styles/options.css
@@ -93,7 +93,7 @@ div#live_preview_checkbox {
     justify-content: center;
 }
 
-div#buttons { position: fixed; bottom: 0px; left: 0px; width: 175px; padding: 10px; }
+div#buttons { position: fixed; top: 0px; left: 0px; width: 175px; padding: 10px; }
 div#buttons button { width: 83px; }
 span#status { 
     color: white;


### PR DESCRIPTION
I didn't do much testing.  Android needed "storage" permission to store the settings and complained about some keys it didn't recognize, so I made a second manifest for Android.  Would be nice if we could use a single manifest; maybe the build script could fix up the desktop manifest.

@WombatFromHell take a look if you'd like

Fixes #105